### PR TITLE
fix build with g++ 11

### DIFF
--- a/libplayercore/message.cc
+++ b/libplayercore/message.cc
@@ -506,7 +506,7 @@ MessageQueue::Push(Message & msg)
           hdr->type == PLAYER_MSGTYPE_CMD) && this->Length >= this->Maxlen)
   {
     // record the fact that we are dropping a message
-    this->drop_count++;
+    this->drop_count = 1;
     this->Unlock();
     return(true);
   }

--- a/server/drivers/dio/bitlogic/bitlogic.cc
+++ b/server/drivers/dio/bitlogic/bitlogic.cc
@@ -108,7 +108,7 @@ class Bitlogic : public Driver
     bool data_valid[MAX_SLOTS];
     int ith;
     int jth;
-    uint32_t compute() const throw (const char *);
+    uint32_t compute() const noexcept(false);
 };
 
 Bitlogic::Bitlogic(ConfigFile * cf, int section) : Driver(cf, section, true, PLAYER_MSGQUEUE_DEFAULT_MAXLEN)
@@ -299,7 +299,7 @@ int Bitlogic::Subscribe(player_devaddr_t addr)
   return 0;
 }
 
-uint32_t Bitlogic::compute() const throw (const char *)
+uint32_t Bitlogic::compute() const noexcept(false)
 {
   uint32_t b;
   int i;


### PR DESCRIPTION
Compilation fails on Ubuntu 21.10 (`g++ (Ubuntu 11.2.0-7ubuntu2) 11.2.0`) because `drop_count` is `bool` and it does not accept `throw` [anymore](https://stackoverflow.com/a/57399855/1273684). 