### PR TITLE
FIX: explicitly do forward declaration on struct for swig file generation

### DIFF
--- a/client_libs/libplayerc/playerc.h
+++ b/client_libs/libplayerc/playerc.h
@@ -407,6 +407,7 @@ PLAYERC_EXPORT int playerc_add_xdr_ftable(playerxdr_function_t *flist, int repla
 /* Forward declare types*/
 struct _playerc_client_t;
 struct _playerc_device_t;
+struct playerc_blackboard;
 
 
 /* forward declaration to avoid including <sys/poll.h>, which may not be


### PR DESCRIPTION
Language bindings use files generated by playerc_swig_parse.py which parses header files, and playerc_swig_parse.py deletes the "tag" in struct definition. This behavior generates incomplete struct definition in generated file, then causes compilation error. To avoid compilation error, do explicit forward declaration for such struct.

Fixes #26 .