### PR TITLE
Fix compilation with OpenCV4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,11 @@ ENDIF (WIN32)
 IF (COMMAND CMAKE_POLICY)
     CMAKE_POLICY (SET CMP0003 NEW)
     CMAKE_POLICY (SET CMP0004 NEW)
+    #CMAKE_POLICY (SET CMP0148 NEW)
 ENDIF (COMMAND CMAKE_POLICY)
 
+# Fix an issue with a forbidden operand when using C++17
+set (CMAKE_CXX_STANDARD 11)
 
 # Set the project name (helps Visual Studio, mainly)
 PROJECT (Player)
@@ -47,6 +50,9 @@ OPTION (PLAYER_BUILD_TESTS "Enables compilation of the test suites" ON)
 
 # Look for various needed things
 INCLUDE (${PLAYER_CMAKE_DIR}/internal/SearchForStuff.cmake)
+# Find and use OpenCV directories
+find_package(OpenCV REQUIRED)
+include_directories(${OpenCV_INCLUDE_DIRS})
 # Give the user some compile options
 INCLUDE (${PLAYER_CMAKE_DIR}/internal/GeneralCompileOptions.cmake)
 # Write the config.h file

--- a/server/drivers/blobfinder/shapetracker/shapetracker.cc
+++ b/server/drivers/blobfinder/shapetracker/shapetracker.cc
@@ -50,8 +50,8 @@ the Player 2.0 API.
 #include <libplayercore/playercore.h>
 #include <base/imagebase.h>
 
-#include <cv.h>
-//#include <highgui.h>
+#include <opencv2/opencv.hpp>
+#include "opencv2/highgui/highgui_c.h"
 
 #define winName "ShapeTracker"
 
@@ -100,7 +100,7 @@ class ShapeTracker : public ImageBase
   private: CvHistogram *hist;
   private: int histSize;
   private: unsigned char lut[256];
-  private: CvMat *lutMat; 
+  private: CvMat *lutMat;
 
   private: double threshold;
   private: int vertices;
@@ -109,8 +109,8 @@ class ShapeTracker : public ImageBase
   private: unsigned int shapeCount;
 
   // Kalmna filters used to track a shape
-  private: CvKalman *kalmanX;
-  private: CvKalman *kalmanY;
+  //private: CvKalman *kalmanX;
+  //private: CvKalman *kalmanY;
   private: int kalmanFirst;
 
   private: CvPoint orientPoint;

--- a/server/drivers/blobfinder/simpleshape/simpleshape.cc
+++ b/server/drivers/blobfinder/simpleshape/simpleshape.cc
@@ -113,7 +113,6 @@ driver
 #include "opencv2/imgproc/imgproc_c.h"
 #include "opencv2/imgcodecs/legacy/constants_c.h"
 
-
 /* CvScalar re-definition */
 inline CvScalar to_CvScalar(cv::Scalar s)
 {
@@ -310,13 +309,17 @@ void SimpleShape::MainQuit()
 int SimpleShape::LoadModel()
 {
   IplImage *img, *work;
+  cv::Mat img2 = cv::cvarrToMat(img);
   CvSize size;
   CvSeq *contour, *maxContour;
   double area, maxArea;
 
   // Load the image
-  img = cvLoadImage( this->modelFilename, 0);
-  if (img == NULL)
+  //img = cvLoadImage( this->modelFilename, 0);
+  img2 = cv::imread( this->modelFilename, cv::IMREAD_GRAYSCALE );
+
+  //if (img == NULL)
+  if ( img2.empty () )
   {
     PLAYER_ERROR("failed to load model file");
     return -1;

--- a/server/drivers/blobfinder/simpleshape/simpleshape.cc
+++ b/server/drivers/blobfinder/simpleshape/simpleshape.cc
@@ -106,8 +106,26 @@ driver
 #include <string.h>
 #include "../../base/imagebase.h"
 
-#include <cv.h>
-#include <highgui.h>
+#include <opencv2/opencv.hpp>
+#include "opencv2/highgui/highgui.hpp"
+#include "opencv2/highgui/highgui_c.h"
+#include "opencv2/imgproc/imgproc.hpp"
+#include "opencv2/imgproc/imgproc_c.h"
+#include "opencv2/imgcodecs/legacy/constants_c.h"
+
+
+/* CvScalar re-definition */
+inline CvScalar to_CvScalar(cv::Scalar s)
+{
+    CvScalar ret;
+
+    ret.val[0] = s.val[0]; // blue
+    ret.val[1] = s.val[1]; // green
+    ret.val[2] = s.val[2]; // red
+    ret.val[3] = s.val[3]; // alpha
+
+    return ret;
+}
 
 // Invariant feature set for a contour
 class FeatureSet
@@ -297,7 +315,7 @@ int SimpleShape::LoadModel()
   double area, maxArea;
 
   // Load the image
-  img = cvLoadImage(this->modelFilename, 0);
+  img = cvLoadImage( this->modelFilename, 0);
   if (img == NULL)
   {
     PLAYER_ERROR("failed to load model file");
@@ -475,8 +493,8 @@ void SimpleShape::FindShapes()
 
     // Draw eligable contour on the output image; useful for debugging
     if (this->debugcam)
-      cvDrawContours(this->outSubImages + 2, contour, CV_RGB(255, 255, 255),
-                     CV_RGB(255, 255, 255), 0, 1, 8);
+      cvDrawContours(this->outSubImages + 2, contour, to_CvScalar(CV_RGB(255, 255, 255)),
+                     to_CvScalar(CV_RGB(255, 255, 255)), 0, 1, 8);
 
     // Compute the contour features
     this->ExtractFeatureSet((CvContour*) contour, &featureSet);
@@ -489,10 +507,10 @@ void SimpleShape::FindShapes()
     // Draw contour on the main image; useful for debugging
     if (this->debugcam)
     {
-      cvDrawContours(this->outSubImages + 3, contour, CV_RGB(128, 128, 128),
-                     CV_RGB(128, 128, 128), 0, 1, 8);
+      cvDrawContours(this->outSubImages + 3, contour, to_CvScalar(CV_RGB(128, 128, 128)),
+                     to_CvScalar(CV_RGB(128, 128, 128)), 0, 1, 8);
       cvRectangle(this->outSubImages + 3, cvPoint(rect.x, rect.y),
-                  cvPoint(rect.x + rect.width, rect.y + rect.height), CV_RGB(255, 255, 255), 1);
+                  cvPoint(rect.x + rect.width, rect.y + rect.height), to_CvScalar(CV_RGB(255, 255, 255)), 1);
     }
 
     // Check for overrun

--- a/server/drivers/blobfinder/upcbarcode/upcbarcode.cc
+++ b/server/drivers/blobfinder/upcbarcode/upcbarcode.cc
@@ -108,8 +108,9 @@ driver
 
 #include "../../base/imagebase.h"
 
-#include <cv.h>
-#include <highgui.h>
+#include <opencv2/opencv.hpp>
+#include "opencv2/highgui/highgui.hpp"
+#include "opencv2/highgui/highgui_c.h"
 
 // Info on potential blobs.
 struct blob_t

--- a/server/drivers/camera/cvcam/cvcam.cc
+++ b/server/drivers/camera/cvcam/cvcam.cc
@@ -26,8 +26,7 @@
 ///////////////////////////////////////////////////////////////////////////
 
 /** @ingroup drivers */
-/** @{ */
-/** @defgroup driver_cvcam cvcam
+/** @{ *//** @defgroup driver_cvcam cvcam
  * @brief OpenCV camera capture
 
 The cvcam driver captures images from cameras through OpenCV infrastructure.
@@ -87,8 +86,11 @@ driver
 #include <pthread.h>
 #include <libplayercore/playercore.h>
 
-#include <cv.h>
-#include <highgui.h>
+#include <opencv2/opencv.hpp>
+#include "opencv2/highgui/highgui.hpp"
+#include "opencv2/highgui/highgui_c.h"
+#include "opencv2/videoio/videoio.hpp"
+#include "opencv2/videoio/videoio_c.h"
 
 //---------------------------------
 

--- a/server/drivers/camera/imageseq/imageseq.cc
+++ b/server/drivers/camera/imageseq/imageseq.cc
@@ -96,8 +96,10 @@ driver
 
 #include <libplayercore/playercore.h>
 
-#include <cv.h>
-#include <highgui.h>
+#include <opencv2/opencv.hpp>
+#include "opencv2/imgproc/imgproc.hpp"
+#include "opencv2/imgproc/imgproc_c.h"
+#include "opencv2/imgcodecs/legacy/constants_c.h"
 
 
 class ImageSeq : public ThreadedDriver
@@ -224,7 +226,7 @@ int ImageSeq::LoadImage(const char *filename)
   switch (image->depth)
   {
 	case IPL_DEPTH_8U:
-	case IPL_DEPTH_8S:
+	case int IPL_DEPTH_8S:
 	  if (image->nChannels == 1)
 	  {
 	    this->data.bpp = 8;
@@ -236,14 +238,14 @@ int ImageSeq::LoadImage(const char *filename)
 		 this->data.format = PLAYER_CAMERA_FORMAT_RGB888;
 	  }
 	break;
-	case IPL_DEPTH_16S:
+	case int IPL_DEPTH_16S:
 	  if (image->nChannels == 1)
 	  {
 	    this->data.bpp = 16;
 		 this->data.format = PLAYER_CAMERA_FORMAT_MONO16;
 	  }
 	break;
-	case IPL_DEPTH_32S:
+	case int IPL_DEPTH_32S:
 	case IPL_DEPTH_32F:
 	case IPL_DEPTH_64F:
 	default:

--- a/server/drivers/camera/imageseq/imageseq.cc
+++ b/server/drivers/camera/imageseq/imageseq.cc
@@ -101,7 +101,6 @@ driver
 #include "opencv2/imgproc/imgproc_c.h"
 #include "opencv2/imgcodecs/legacy/constants_c.h"
 
-
 class ImageSeq : public ThreadedDriver
 {
   // Constructor
@@ -205,10 +204,14 @@ int ImageSeq::LoadImage(const char *filename)
   char *src;
   uint8_t *dst;
   IplImage *image;
+  cv::Mat image2 = cv::cvarrToMat(image);
 
   // Load image; currently forces the image to mono
-  image = cvLoadImage(filename, -1);
-  if(image == NULL)
+  //image = cvLoadImage(filename, -1);
+  image2 = cv::imread( filename, cv::IMREAD_UNCHANGED );
+
+  //if(image == NULL)
+  if( image2.empty() )
   {
   		PLAYER_ERROR1("Could not load image file: %s", filename);
 		return -1;

--- a/server/drivers/camera/videocanny/videocanny.cc
+++ b/server/drivers/camera/videocanny/videocanny.cc
@@ -86,8 +86,9 @@ driver
 #include <libplayercore/playercore.h>
 #include <libplayerjpeg/playerjpeg.h>
 
-#include <cv.h>
-#include <highgui.h>
+#include <opencv2/opencv.hpp>
+#include "opencv2/highgui/highgui.hpp"
+#include "opencv2/highgui/highgui_c.h"
 
 typedef enum { canny = 0, sobel, laplace } func_t;
 


### PR DESCRIPTION
This PR modified some parts of the main CMakeLists to compile with C++11, and also search for an installation of OpenCV.
Additionally, changes to header includes were made, as well as adding other missing headers so they legacy C API functions are properly recognized with the latest iteration of OpenCV.

I redefined `cvScalar` in a couple of files, and also converted `cvLoadImage` to now use `cv::imread` instead by converting it with `cvarrToMat`. 

**_Someone with the proper knowledge, please review this properly before merging._**
Let me know if I missed anything or if I did something wrong.

This PR should fix Issue #28 which I created some time ago.